### PR TITLE
fix: remove settings et al

### DIFF
--- a/client/cluster.go
+++ b/client/cluster.go
@@ -40,40 +40,8 @@ type Cluster struct {
 		TerseBucketsBase          string `json:"terseBucketsBase"`
 		TerseStreamingBucketsBase string `json:"terseStreamingBucketsBase"`
 	} `json:"buckets"`
-	RemoteClusters struct {
-		URI         string `json:"uri"`
-		ValidateURI string `json:"validateURI"`
-	} `json:"remoteClusters"`
-	RebalanceStatus        string  `json:"rebalanceStatus"`
-	MaxBucketCount         float64 `json:"maxBucketCount"`
-	AutoCompactionSettings struct {
-		ParallelDBAndViewCompaction    bool `json:"parallelDBAndViewCompaction"`
-		DatabaseFragmentationThreshold struct {
-			Percentage float64 `json:"percentage"`
-			Size       string  `json:"size"`
-		} `json:"databaseFragmentationThreshold"`
-		ViewFragmentationThreshold struct {
-			Percentage float64 `json:"percentage"`
-			Size       string  `json:"size"`
-		} `json:"viewFragmentationThreshold"`
-		IndexCompactionMode     string `json:"indexCompactionMode"`
-		IndexCircularCompaction struct {
-			DaysOfWeek string `json:"daysOfWeek"`
-			Interval   struct {
-				FromHour     float64 `json:"fromHour"`
-				ToHour       float64 `json:"toHour"`
-				FromMinute   float64 `json:"fromMinute"`
-				ToMinute     float64 `json:"toMinute"`
-				AbortOutside bool    `json:"abortOutside"`
-			} `json:"interval"`
-		} `json:"indexCircularCompaction"`
-		IndexFragmentationThreshold struct {
-			Percentage float64 `json:"percentage"`
-		} `json:"indexFragmentationThreshold"`
-	} `json:"autoCompactionSettings"`
-	Tasks struct {
-		URI string `json:"uri"`
-	} `json:"tasks"`
+	RebalanceStatus     string   `json:"rebalanceStatus"`
+	MaxBucketCount      float64  `json:"maxBucketCount"`
 	Counters            Counters `json:"counters"`
 	IndexStatusURI      string   `json:"indexStatusURI"`
 	CheckPermissionsURI string   `json:"checkPermissionsURI"`

--- a/collector/cluster.go
+++ b/collector/cluster.go
@@ -267,7 +267,6 @@ func (c *clusterCollector) Collect(ch chan<- prometheus.Metric) {
 		log.With("error", err).Error("failed to scrape cluster")
 		return
 	}
-	ch <- prometheus.MustNewConstMetric(c.up, prometheus.GaugeValue, 1)
 
 	ch <- prometheus.MustNewConstMetric(c.balanced, prometheus.GaugeValue, fromBool(cluster.Balanced))
 	ch <- prometheus.MustNewConstMetric(c.ftsMemoryQuota, prometheus.GaugeValue, cluster.FtsMemoryQuota*1024*1024)
@@ -298,5 +297,6 @@ func (c *clusterCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(c.storagetotalsHddUsedbydata, prometheus.GaugeValue, cluster.StorageTotals.Hdd.UsedByData)
 	ch <- prometheus.MustNewConstMetric(c.storagetotalsHddFree, prometheus.GaugeValue, cluster.StorageTotals.Hdd.Free)
 
+	ch <- prometheus.MustNewConstMetric(c.up, prometheus.GaugeValue, 1)
 	ch <- prometheus.MustNewConstMetric(c.scrapeDuration, prometheus.GaugeValue, time.Since(start).Seconds())
 }

--- a/collector/node.go
+++ b/collector/node.go
@@ -178,7 +178,6 @@ func (c *nodesCollector) Collect(ch chan<- prometheus.Metric) {
 		log.With("error", err).Error("failed to scrape nodes")
 		return
 	}
-	ch <- prometheus.MustNewConstMetric(c.up, prometheus.GaugeValue, 1)
 
 	// nolint: lll
 	for _, node := range nodes.Nodes {
@@ -200,6 +199,7 @@ func (c *nodesCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(c.interestingStatsEpBgFetched, prometheus.GaugeValue, node.InterestingStats.EpBgFetched, node.Hostname)
 	}
 
+	ch <- prometheus.MustNewConstMetric(c.up, prometheus.GaugeValue, 1)
 	// nolint: lll
 	ch <- prometheus.MustNewConstMetric(c.scrapeDuration, prometheus.GaugeValue, time.Since(start).Seconds())
 }

--- a/collector/task.go
+++ b/collector/task.go
@@ -136,7 +136,6 @@ func (c *taskCollector) Collect(ch chan<- prometheus.Metric) {
 		log.With("error", err).Error("failed to scrape tasks")
 		return
 	}
-	ch <- prometheus.MustNewConstMetric(c.up, prometheus.GaugeValue, 1)
 
 	var compactsReported = map[string]bool{}
 	// nolint: lll
@@ -178,6 +177,7 @@ func (c *taskCollector) Collect(ch chan<- prometheus.Metric) {
 		compactsReported[bucket.Name] = true
 	}
 
+	ch <- prometheus.MustNewConstMetric(c.up, prometheus.GaugeValue, 1)
 	// nolint: lll
 	ch <- prometheus.MustNewConstMetric(c.scrapeDuration, prometheus.GaugeValue, time.Since(start).Seconds())
 }

--- a/prometheus/rules/couchbase.rules.yml
+++ b/prometheus/rules/couchbase.rules.yml
@@ -153,3 +153,11 @@ groups:
       severity: warning
     annotations:
       summary: 'Couchbase XDCR from {{ $labels.bucket }} to {{ $labels.target }} is erroring'
+  - alert: CouchbaseScrapeError
+    expr: couchbase_bucket_up == 0 OR couchbase_cluster_up == 0 OR couchbase_node_up == 0 OR couchbase_task_up == 0
+    for: 1m
+    labels:
+      severity: critical
+    annotations:
+      summary: 'Couchbase is failing to scrape {{ $labels.instance }}'
+      description: 'It may be a problem within the cluster or a bug in the exporter.'


### PR DESCRIPTION
we don't really use those things for anything, but, if the cluster has autocompacting disabled it may return a `undefined` instead of a number in some fields, causing scraping errors...